### PR TITLE
Fixed crash during plugins installation on Linux (#7)

### DIFF
--- a/api/installer.js
+++ b/api/installer.js
@@ -153,31 +153,26 @@ class Installer extends Api {
     this.onDownloadProgress.dispatch({id, percentDownloaded: 0});
     this.onInstallStageChanged.dispatch(
         {id, stage: this.InstallStage.DOWNLOADING});
-    chrome.downloads.download(options);
-    return new Promise((onUnpacked, onError) => {
-      let interv = setInterval(() => {
-        Promise
-            .all([
-              this.getExtension_(id),
-              this.getDownload_(options.url),
-            ])
-            .then(details => {
-              const [extension, download] = details;
-              if (extension) {
-                clearInterval(interv);
-                this.onDownloadProgress.dispatch({id, percentDownloaded: 1});
-                onUnpacked();
-              } else if (download && download.error) {
-                clearInterval(interv);
-                alert(chrome.i18n.getMessage('installerErrorNetwork'));
-                onError();
-              } else if (Date.now() > maxTime) {
-                clearInterval(interv);
-                alert(chrome.i18n.getMessage('installerErrorTimeout'));
-                onError();
-              }
-            });
-      }, 1000);
+    return new Promise((resolve, reject) => {
+      
+      chrome.downloads.download(options, (downloadId) => {
+        if (downloadId) {
+          this.onDownloadProgress.dispatch({id, percentDownloaded: 1});
+          resolve();
+        } else {
+          this.getDownload_(options.url).then((download) => {
+            if (download && download.error) {
+              alert(chrome.i18n.getMessage('installerErrorNetwork'));
+            } else if (Date.now() > maxTime) {
+              alert(chrome.i18n.getMessage('installerErrorTimeout'));
+            }
+            reject();            
+          }).catch(() => {
+            reject();
+          });
+        }
+      });
+      
     });
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
       "/background/app.js"
     ]
   },
-  "version": "2.4.0",
+  "version": "2.4.1",
   "manifest_version": 2,
   "page_action": {
     "default_icon": "icons/19.png",


### PR DESCRIPTION
* Fix problem in installer.js that crashes Opera on Linux.
* Update version to 2.4.1